### PR TITLE
rbuild: Enhancements to support CMake

### DIFF
--- a/rbuild
+++ b/rbuild
@@ -1,333 +1,1004 @@
-#!/bin/bash
+#! /bin/sh
+# vim: noai:noet:ci:sts=0:ts=4:sw=4:colorcolumn=80
 
-LC_CTYPE=C
-SSH="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ForwardAgent=yes"
-LOCAL_DIR_ANCHORS=".hg .git configure.ac"
-BUILD_ENV=debug
-INSTALL_DIR='$HOME/.local'
-BUILD_JOBS=8
-RBUILD_DIR=rbuild
+# SPDX-License-Identifier: MIT
 
-upsearch () {
-    slashes=${PWD//[^\/]/}
-    directory="$PWD"
-    for (( n=${#slashes}; n>0; --n ))
-    do
-        for i in $*; do
-            test -e "$directory/$i" && echo "$directory/$i" && return
-        done
-        directory="$directory/.."
-    done
+# Global settings
+export LC_CTYPE=C
+export TERM=xterm
+
+# Configurations:User
+RUSER=
+RB_PROFILES=
+
+# Configuration:Locations
+RB_LOCAL_DIR_ANCHORS=".git .hg"
+RB_JOBS=1
+# Remote host on which sources/binaries will be generated
+RB_BHOST=
+# Deploy host
+RB_DHOST=
+# Root directory on remote site where source and binaries will be placed.
+RB_ROOT=
+
+# Configurations:Tools
+RSYNC=$(which rsync)
+# Some Distro package managers name `cmake` executable differently. Use the
+# correct name of full path as available on build host.
+CMAKE_EXE=
+CTEST_EXE=
+# CMake generator to use. If unset, it uses whatever is system default. Usually,
+# that's "Unix Makefiles".
+CMAKE_GENERATOR=
+# Colon separated list of paths CMake will look for headers/libraries.
+CMAKE_PREFIX_PATH=
+# Any other extra project-specific arguments to send to CMake configuration
+CMAKE_EXTRAS=
+
+# Local settings
+
+# Configuration file to load
+rb_cfg_file=
+# Verbosity levels (cumulative).
+#     1 - Show only the task names
+#     2 - Turn on make/ninja verbosity
+#     3 - Show the actual SSH command being transmitted
+#     4 - Turn on full verbosity, even in SSH
+rb_verbosity=0
+# SSH flags. Note, verbosity settings will append -o LogLevel=QUIET later on
+ssh_flags="-o BatchMode=yes -o StrictHostKeyChecking=no -o ForwardAgent=yes"
+# Build configuration
+rb_build_mode=debug
+CMAKE_BUILD_TYPE=Debug
+# Make target
+rb_target=
+# Directories
+ldir_src= # Discovered by rb_init()
+rdir_src=
+rdir_bin=
+rdir_ins=
+
+# Actions
+__rb_is_build=0
+__rb_is_config=0
+__rb_is_deploy=0
+__rb_is_pack=0
+__rb_is_reset=0
+__rb_is_rsync=0
+__rb_is_test=0
+__rb_reset_level=0
+__rb_is_dryrun=0
+
+# Internal constants
+ME=$(basename ${0})
+
+# Too many jobs can hinder others' works. For safety, use count of local CPUs.
+__rb_def_jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) || 1
+__rb_def_cfg_name=.rbuild.conf
+
+__rb_blue=$(tput setaf 4)
+__rb_red=$(tput setaf 1)
+__rb_norm=$(tput sgr0)
+
+__rb_excludes=""
+__rb_excludes="${__rb_excludes}*.swp\n"
+__rb_excludes="${__rb_excludes}.git\n"
+__rb_excludes="${__rb_excludes}.gitignore\n"
+__rb_excludes="${__rb_excludes}.hg\n"
+__rb_excludes="${__rb_excludes}aclocal.m4\n"
+__rb_excludes="${__rb_excludes}autom4te.cache\n"
+__rb_excludes="${__rb_excludes}build-aux\n"
+__rb_excludes="${__rb_excludes}compile\n"
+__rb_excludes="${__rb_excludes}config.guess\n"
+__rb_excludes="${__rb_excludes}config.sub\n"
+__rb_excludes="${__rb_excludes}configure\n"
+__rb_excludes="${__rb_excludes}depcomp\n"
+__rb_excludes="${__rb_excludes}install-sh\n"
+__rb_excludes="${__rb_excludes}libtool.m4\n"
+__rb_excludes="${__rb_excludes}ltmain.sh\n"
+__rb_excludes="${__rb_excludes}ltoptions.m4\n"
+__rb_excludes="${__rb_excludes}ltsugar.m4\n"
+__rb_excludes="${__rb_excludes}ltversion.m4\n"
+__rb_excludes="${__rb_excludes}lt~obsolete.m4\n"
+__rb_excludes="${__rb_excludes}Makefile.in\n"
+__rb_excludes="${__rb_excludes}missing\n"
+__rb_excludes="${__rb_excludes}py-compile\n"
+__rb_excludes="${__rb_excludes}test-driver\n"
+__rb_excludes="${__rb_excludes}ylwrap\n"
+
+
+# Show help message
+rb_help()
+{
+	exit_code=${1}
+	msg=${2}
+
+	if [ ! -z "${msg}" ]; then
+		echo "${msg}" >&2
+	fi
+
+	echo "Remote build driver for auto-tools/CMake/GNUMake"
+	echo
+	echo "Usage: ${ME} <-j JOBS> <-C FILE> <-e MODE> [-nv*] -[scbtp]"
+	echo
+	echo "-h        This help message"
+	echo
+	echo "-b        Build"
+	echo "-B        Select custom target, for e.g. '-Bdocs'"
+	echo "-c        (re)Configure"
+	echo "-C [FILE] Configuration file to load"
+	echo "-d        Deploy"
+	echo "-e [MODE] Build mode, one of [debug, optimized]. (Default: 'debug')."
+	echo "-j [JOBS] Change default number of jobs (Default: RB_JOBS=${__rb_def_jobs})."
+	echo "-n        Dry run. Print command only."
+	echo "-p        Generate archive of remote installation directory"
+	echo "-r [TYPE] Scrub remote directories. For different TYPE values:"
+	echo "            1. Run \`make clean\` or equivalent"
+	echo "            2. Delete remote binary directory"
+	echo "            3. Delete remote install directory"
+	echo "            4. Delete remote source directory"
+	echo "-s        Sync local source to remote directory"
+	echo "-t        Test"
+	echo "-v        More '-v', more drama!"
+	echo
+
+	exit ${exit_code}
 }
 
-function load_conf {
-    if [ -z $1 ]; then
-        conf=$(upsearch .rbuild.conf)
-    else
-        conf=$1
-    fi
+# Write a success/fail log message on terminal
+#
+# \param $1 - Exit code
+# \param $2 - Task
+# \param $3 - Time taken
+rb_log()
+{
+	exit_code=$1
+	task=$2
+	diff_time=$3
 
-    if [ -z "$conf" ]; then
-        if [ -e $HOME/.rbuild.conf ]; then
-            . $HOME/.rbuild.conf
-        else
-            echo >&2 "Could not find required file .rbuild.conf or ~/.rbuild.conf"
-            echo >&2 "Please create one and rerun to get additional instructions"
-            exit 1
-        fi
-    else
-        . "$conf"
-    fi
-
-    LOCAL_DIR=${LOCAL_DIR:-$(dirname "$(upsearch $LOCAL_DIR_ANCHORS)")}
-    # cd into dir to normalize it
-    cd "$LOCAL_DIR"
-    LOCAL_DIR=$PWD
-    BASENAME=${BASENAME:-$(basename "$LOCAL_DIR")}
-    STAGING_DIR="${STAGING_DIR:-$RBUILD_DIR/$BASENAME}"
-    BUILD_DIR=${BUILD_DIR:-$RBUILD_DIR/$BASENAME.$BUILD_ENV}
-
-    if [ -z "$BUILD_HOST" ]; then
-        echo >&2 "BUILD_HOST not set"
-        echo >&2 "Please set it in .rbuild.conf, for example: BUILD_HOST=somehost"
-        echo >&2 "The host name is resolved on your local machine"
-        exit 1
-    fi
+	if [ ${exit_code} -ne 0 ]; then
+		printf "${__rb_red}[%12s]${__rb_norm} failed after %ds. Aborting..\n" \
+			"${task}" \
+			${diff_time}
+		exit $exit_code
+	fi
+	if [ ${rb_verbosity} -ge 1 ]; then
+		printf "${__rb_blue}[%12s]${__rb_norm} finished in %ds.\n" \
+			"${task}" \
+			${diff_time}
+	fi
 }
 
+# Run $* remotely.
+#
+# \param $1 A human readable name of the task executed remotely
+# \param $2 Remote host
+# \param $3 Command to execute on remote server
+#
+# \example
+# Call this function as:
+#     ssh_call "ls" "example.com" "ls --color=always -lh /usr/include"
+ssh_call()
+{
+	args=
+	ret=
+	cmdline=
 
-function stage {
-    echo Staging source from $LOCAL_DIR to $BUILD_HOST:$STAGING_DIR
+	task=${1}
+	shift
 
-    if [ -e "$PWD/.rbuild.exclude" ]; then
-        echo >&2 "Using rsync exclude file $PWD/.rbuild.exclude"
-        exec 100< "$PWD/.rbuild.exclude"
-    else
-        if [ -e $HOME/.rbuild.exclude ]; then
-            echo >&2 "Using rsync exclude file $HOME/.rbuild.exclude"
-            exec 100< "$HOME/.rbuild.exclude"
-        else
-            echo >&2 "Using built-in rsync exclude file list (displayed with $0 -x)"
-            tmpfile=$(mktemp)
-            dump_exclude_list > "$tmpfile"
-            exec 100< "$tmpfile"
-            rm "$tmpfile"
-        fi
-    fi
+	# Set some SSH flags
+	args="${__ssh_flags}"
+	# If `rbuild` is invoked from shell, request pseudo terminal for SSH
+	if [ -t 1 ] || [ -t 2 ]; then
+		args="${args} -t"
+	fi
+	# If verbosity levels are too high, start true crime drama with SSH
+	if [ ${rb_verbosity} -ge 4 ]; then
+		args="${args} -v"
+	fi
+	# If there's a remote user specified, set that too. Otherwise assume
+	# whatever the current local user's ~/.ssh/config says about RB_HOST.
+	if [ ! -z "${RUSER}" ]; then
+		args="${args} -l${RUSER}"
+	fi
+	# Set remote host
+	args="${args} ${1}"
+	# Use remote profile settings. If scripts are specified in RB_POFILES, those
+	# scripts are sourced before running the actual commands. For example, some
+	# compilers provide `enable` script to temporarily switch over to that
+	# compiler in PATH. Setting RB_PROFILES can enable that for this SSH session.
+	if [ ! -z "${RB_PROFILES}" ]; then
+		for p in $(echo "${RB_PROFILES}" | sed "s/:/ /g"); do
+			cmdline=". ${p}; "
+		done
+	fi
+	# Finally inject the remaining command.
+	cmdline="${cmdline}${2}"
 
-    RSYNC_OLD_ARGS=1 rsync -r -l -c --executability --del --inplace  -z -e "$SSH" --rsync-path="mkdir -p \"$STAGING_DIR\" && rsync" --cvs-exclude --exclude .hg --exclude .git --exclude-from <(cat <&100) "$LOCAL_DIR/" "$BUILD_HOST:\"$STAGING_DIR\""
+	if [ ${rb_verbosity} -ge 3 ] || [ ${__rb_is_dryrun} -eq 1 ]; then
+		echo "ssh ${args} \"${cmdline}\""
+	fi
+
+	# Timing the command here will include the time spent on network as well.
+	# Shouldn't be too relevant over multiple runs.
+	diff_time=0
+	ret=0
+	if [ ${__rb_is_dryrun} -eq 0 ]; then
+		t_start=$(date +%s)
+		ssh ${args} ${cmdline}
+		ret=$?
+		t_end=$(date +%s)
+		diff_time=$(expr $t_end - $t_start)
+	fi
+
+	rb_log ${ret} ${task} ${diff_time}
 }
 
-function autoreconf {
-    echo Remote autoreconf in $BUILD_HOST:$STAGING_DIR
-    $SSH $BUILD_HOST "cd \"$STAGING_DIR\" && eval $AUTORECONF_VARS autoreconf --install"
+# Locate one or more files either in current directory or its parents until that
+# file is found.
+upsearch()
+{
+	ldir=
+	pdir=
+
+	for file in "$@"; do
+		ldir=$(pwd)
+		is_found=0
+		while [ -n "${ldir}" ]; do
+			if [ -e "${ldir}/${file}" ]; then
+				echo "${ldir}"
+				is_found=1
+				break
+			fi
+			pdir=$(dirname "${ldir}")
+
+			if [ "${ldir}" = "${pdir}" ]; then
+				break
+			fi
+			ldir="${pdir}"
+		done
+		if [ ${is_found} -eq 1 ]; then
+			break
+		fi
+	done
+
+	echo ""
 }
 
-function configure {
-    echo Remote configure in $BUILD_HOST:$BUILD_DIR
-    $SSH $BUILD_HOST "mkdir -p \"$BUILD_DIR\" && cd \"$BUILD_DIR\" && eval $CONFIGURE_VARS \"../$BASENAME/configure\" $CONFIGURE_ARGS"
+# Prepare exclude list
+x_file=
+rb_prep_exclist()
+{
+	x_file=$(mktemp)
+	u_file="${x_file}u"
+	printf "${__rb_excludes}" > "${x_file}"
+	# If the current directory contains a list, append that too
+	if [ -f .rbuild.exclude ]; then
+		cat .rbuild.exclude >> "${x_file}"
+	fi
+	uniq "${x_file}" > "${u_file}"
+	mv "${u_file}" "${x_file}"
 }
 
-function build {
-    echo Remote build $1 in $BUILD_HOST:$BUILD_DIR
-    $SSH $BUILD_HOST "$BUILD_VARS make -C $BUILD_DIR -j$BUILD_JOBS $1"
+# Synchronise local sources to remote site.
+#
+rb_sync()
+{
+	r_args= # For rSync
+	s_args= # For SSH
+
+	rb_prep_exclist
+
+	r_args="-chlrz"
+	if [ $rb_verbosity -ge 2 ]; then
+		r_args="${r_args} -v --progress"
+	else
+		r_args="${r_args} -q"
+	fi
+	r_args="${r_args} --inplace"
+	r_args="${r_args} --del"
+	r_args="${r_args} --cvs-exclude"
+	r_args="${r_args} --exclude-from=${x_file}"
+
+	s_args="ssh ${__ssh_flags}"
+
+	r_path=
+	if [ ! -z "${RUSER}" ]; then
+		r_path="${RUSER}@${RB_BHOST}"
+	else
+		r_path="${RB_BHOST}"
+	fi
+	r_path="${r_path}:${rdir_src}/"
+
+	if [ $rb_verbosity -ge 3 ] || [ ${__rb_is_dryrun} -ne 0 ]; then
+		_txt="RSYNC_OLD_ARGS=1 rsync"
+		_txt="${_txt} ${r_args} -e ${s_args}"
+		_txt="${_txt} --rsync-path=\"mkdir -p ${rdir_src} && ${RSYNC}\""
+		_txt="${_txt} ${ldir_src}/ ${r_path}"
+		echo ${_txt}
+		_txt=
+	fi
+
+	diff_time=0
+	ret=0
+	if [ ${__rb_is_dryrun} -eq 0 ]; then
+		t_start=$(date +%s)
+		RSYNC_OLD_ARGS=1 rsync \
+			${r_args} \
+			-e "${s_args}" \
+			--rsync-path="mkdir -p ${rdir_src} && ${RSYNC}" \
+			${ldir_src}/ "${r_path}"
+		ret=$?
+		t_end=$(date +%s)
+		diff_time=$(expr $t_end - $t_start)
+	fi
+
+	rm -f "${x_file}"
+
+	rb_log ${ret} "rsync" ${diff_time}
 }
 
-function check {
-    echo Running tests in $BUILD_HOST:$BUILD_DIR
-    $SSH $BUILD_HOST "make -C $BUILD_DIR check || cat $BUILD_DIR/test-suite.log"
+# Load configuration file and initialise build environment
+rb_init()
+{
+	if [ -z "${rb_cfg_file}" ]; then
+		echo "Configuration does not exist"
+		exit 1
+	fi
+
+	ldir_src=$(upsearch ${RB_LOCAL_DIR_ANCHORS})
+	if [ -z "${ldir_src}" ]; then
+		echo "Cannot locate local source repository"
+		exit 1
+	fi
+
+	if [ -f "${ldir_src}/CMakeLists.txt" ]; then
+		rb_method="cmake"
+	elif [ -f "${ldir_src}/configure.ac" ]; then
+		rb_method="auto"
+	elif [ -f "${ldir_src}/Makefile" ] || [ -f "${ldir_src}/GNUMakefile" ]; then
+		rb_method="make"
+	else
+		echo "Could not recognise build method."
+		echo "No Makefile/CMakeLists.txt/configure.ac found in ${ldir_src}"
+		exit 1
+	fi
+
+	# Load configuration
+	. ${rb_cfg_file}
+
+	if [ -z "${RB_BHOST}" ]; then
+		echo "No build-host specified."
+		exit 1
+	fi
+	if [ -z "${RB_ROOT}" ]; then
+		echo "No build-root directory specified."
+		exit 1
+	fi
+
+	_name=$(basename "${ldir_src}")
+	rdir_src="${RB_ROOT}/${_name}"
+	rdir_bin="${RB_ROOT}/${_name}.${rb_build_mode}"
+	rdir_ins="${RB_ROOT}/${rb_build_mode}"
+
+	if [ "${rb_method}" = "auto" ]; then
+		__saved_jobs=${RB_JOBS}
+		# In case of auto-tools reload the configuration once more so
+		# `AUTO_EXTRA_CONFIGURE_ARGS` can be fine tuned with our newly
+		# discovered variables. Clear out all the variables to start fresh as
+		# sometimes they may just be adding on themselves.
+		AUTO_EXTRA_CONFIGURE_ARGS=
+		CMAKE_EXE=
+		CMAKE_EXTRAS=
+		CMAKE_GENERATOR=
+		CMAKE_PREFIX_PATH=
+		CTEST_EXE=
+		PKG_CONFIG_PATH=
+		RB_BHOST=
+		RB_DHOST=
+		RB_ROOT=
+		RSYNC=
+		RUSER=
+		AR=
+		CC=
+		CCAS=
+		CXX=
+		LINKER=
+		NM=
+		RANLIB=
+		STRIP=
+
+		. "${rb_cfg_file}"
+
+		RB_JOBS=${__saved_jobs}
+	fi
 }
 
-function clean {
-    echo Remote clean in $BUILD_HOST:$BUILD_DIR
-    $SSH $BUILD_HOST "make -C $BUILD_DIR clean"
+# Reset remote site
+rb_reset()
+{
+	rm_cmd="rm -rf"
+	if [ ${rb_verbosity} -ge 2 ]; then
+		rm_cmd="${rm_cmd} -v"
+	fi
+
+	if [ ${__rb_reset_level} -eq 1 ]; then
+		if [ "${rb_method}" = "cmake" ]; then
+			# With CMake it's best to trigger `clean` target by letting CMake
+			# decide how to call it using the right generator.
+			if [ -z "${CMAKE_EXE}" ]; then
+				args="cmake"
+			else
+				args="${CMAKE_EXE}"
+			fi
+			args="${args} --build ${rdir_bin}"
+			args="${args} -j ${RB_JOBS}"
+			if [ ! -z "${rb_target}" ]; then
+				args="${args} -t ${rb_target}"
+			else
+				args="${args} -t clean"
+			fi
+
+			if [ ${rb_verbosity} -ge 2 ]; then
+				args="${args} -v"
+			fi
+
+			ssh_call "Reset-1" "${RB_BHOST}" "${args}"
+		elif [ "${rb_method}" = "auto" ] || [ "${rb_method}" = "make" ]; then
+			args="make"
+			args="${args} -C${rdir_bin}"
+			args="${args} -j${RB_JOBS}"
+
+			# We assume both handmade Makefile and autotools generated Makefile
+			# use `V=1` to enable verbosity.
+			if [ ${rb_verbosity} -ge 2 ]; then
+				args="${args} V=1"
+			fi
+
+			if [ ! -z "${rb_target}" ]; then
+				args="${args} ${rb_target}"
+			else
+				args="${args} clean"
+			fi
+
+			ssh_call "Reset-1" "${RB_BHOST}" "${args}"
+		fi
+		return 0
+	fi
+
+	args="cd ${RB_ROOT}; ${rm_cmd}"
+	if [ ${__rb_reset_level} -ge 4 ]; then
+		args="${args} ${rdir_src}"
+	fi
+	if [ ${__rb_reset_level} -ge 3 ]; then
+		args="${args} ${rdir_ins}"
+	fi
+	if [ ${__rb_reset_level} -ge 2 ]; then
+		args="${args} ${rdir_bin}"
+		if [ ${rb_method} = "auto" ]; then
+			# Only in auto-tools mode. Delete these excess files so we can run
+			# autoreconf --install again.
+			args="${args} ${rdir_src}/configure"
+			args="${args} ${rdir_src}/build-aux"
+			args="${args} ${rdir_src}/autom4te.cache"
+			args="${args} ${rdir_src}/aclocal.m4"
+		fi
+	fi
+	ssh_call "Reset-${__rb_reset_level}" "${RB_BHOST}" "${args}"
 }
 
-function rm_build_dir {
-    echo Removing $BUILD_HOST:$BUILD_DIR
-    $SSH $BUILD_HOST "rm -rf \"$BUILD_DIR\""
+auto_config()
+{
+	envs=""
+	if [ ! -z "${SCAN_BUILD}" ]; then
+		envs="${envs} CC=${SCAN_BUILD}"
+		envs="${envs} CXX=${SCAN_BUILD}"
+	else
+		if [ ! -z "${CC}" ]; then
+			envs="${envs} CC=${CC}"
+		fi
+		if [ ! -z "${CXX}" ]; then
+			envs="${envs} CXX=${CXX}"
+		fi
+	fi
+	if [ ! -z "${AR}" ]; then
+		envs="${envs} AR=${AR}"
+	fi
+	if [ ! -z "${RANLIB}" ]; then
+		envs="${envs} RANLIB=${RANLIB}"
+	fi
+	if [ ! -z "${NM}" ]; then
+		envs="${envs} NM=${NM}"
+	fi
+	if [ ! -z "${LINKER}" ]; then
+		envs="${envs} LINKER=${LINKER}"
+	fi
+	if [ ! -z "${CCAS}" ]; then
+		envs="${envs} CCAS=${CCAS}"
+	fi
+	if [ ! -z "${CFLAGS}" ]; then
+		envs="${envs} CFLAGS=\"${CFLAGS}\""
+	fi
+	if [ ! -z "${CXXFLAGS}" ]; then
+		envs="${envs} CXXFLAGS=\"${CXXFLAGS}\""
+	fi
+	if [ ! -z "${GIT_REVISION}" ]; then
+		envs="${envs} GIT_REVISION=${GIT_REVISION}"
+	fi
+	envs="${envs} ACLOCAL_PATH=${rdir_ins}/share/aclocal"
+	envs="${envs} PKG_CONFIG_PATH=${rdir_ins}/lib/pkgconfig:${rdir_ins}/lib64/pkgconfig"
+	if [ ! -z "${PKG_CONFIG_PATH}" ]; then
+		envs="${envs}:${PKG_CONFIG_PATH}"
+	fi
+
+	s_args="${__ssh_flags}"
+	if [ ! -z "${RUSER}" ]; then
+		s_args="${s_args} -l${RUSER}"
+	fi
+	s_args="${s_args} ${RB_BHOST}"
+
+	if ! ssh ${s_args} "test -f ${rdir_src}/configure"; then
+		# Call auto-reconf
+		cmd=
+		cmd="${envs} autoreconf --install"
+		ssh_call "Setup" \
+			"${RB_BHOST}" \
+			"mkdir -p ${rdir_src} && cd ${rdir_src} && ${cmd}"
+	fi
+	# Then call configure script
+	cmd=
+	cmd="${envs} ${rdir_src}/configure"
+	cmd="${cmd} --prefix=${rdir_ins}"
+	if [ -z "${AUTO_EXTRA_CONFIGURE_ARGS}" ]; then
+		cmd="${cmd} ${AUTO_EXTRA_CONFIGURE_ARGS}"
+	fi
+	ssh_call "Configure" \
+		"${RB_BHOST}" \
+		"mkdir -p ${rdir_bin} && cd ${rdir_bin} && ${cmd}"
 }
 
-function rm_install_dir {
-    echo Removing $BUILD_HOST:$INSTALL_DIR/$BASENAME
-    $SSH $BUILD_HOST "rm -rf \"$INSTALL_DIR/$BASENAME\""
+cmake_config()
+{
+	args=
+
+	# args="PKG_CONFIG_ALLOW_SYSTEM_LIBS=0"
+	args="${args} PKG_CONFIG_PATH=${rdir_ins}/lib/pkgconfig:${rdir_ins}/lib64/pkgconfig"
+	if [ ! -z "${PKG_CONFIG_PATH}" ]; then
+		args="${args}:${PKG_CONFIG_PATH}"
+	fi
+	if [ ! -z "${GIT_REVISION}" ]; then
+		args="${args} GIT_REVISION=${GIT_REVISION}"
+	fi
+
+	if [ -z "${CMAKE_EXE}" ]; then
+		args="${args} cmake"
+	else
+		args="${args} ${CMAKE_EXE}"
+	fi
+	args="${args} -S${rdir_src}"
+	args="${args} -B${rdir_bin}"
+	args="${args} -Werror=dev"
+	args="${args} --warn-uninitialized"
+	args="${args} --no-warn-unused-cli"
+
+	if [ ! -z "${CMAKE_GENERATOR}" ]; then
+		args="${args} -G\"${CMAKE_GENERATOR}\""
+	fi
+	if [ ! -z "${CC}" ]; then
+		args="${args} -DCMAKE_C_COMPILER=${CC}"
+	fi
+	if [ ! -z "${CXX}" ]; then
+		args="${args} -DCMAKE_CXX_COMPILER=${CXX}"
+	fi
+	if [ ! -z "${AR}" ]; then
+		args="${args} -DCMAKE_AR=${AR}"
+	fi
+	if [ ! -z "${RANLIB}" ]; then
+		args="${args} -DCMAKE_RANLIB=${RANLIB}"
+	fi
+	if [ ! -z "${NM}" ]; then
+		args="${args} -DCMAKE_NM=${NM}"
+	fi
+	if [ ! -z "${LINKER}" ]; then
+		args="${args} -DCMAKE_LINKER=${LINKER}"
+	fi
+	if [ ! -z "${STRIP}" ]; then
+		args="${args} -DCMAKE_STRIP=${STRIP}"
+	fi
+	if [ ! -z "${CMAKE_EXTRAS}" ]; then
+		args="${args} ${CMAKE_EXTRAS}"
+	fi
+
+	# TODO - This disables "Installing: blah/blah" or "Up-to-Date: blah/blah"
+	# message. But once passed in configuration it can't be modified later
+	# through rbuild CLI. For large projects, this will print way too many
+	# lines obstructing the real stuff. Should this be configured here under
+	# `-v` settings?
+	if [ ${rb_verbosity} -ge 2 ]; then
+		args="${args} -DCMAKE_INSTALL_MESSAGE=ALWAYS"
+	else
+		args="${args} -DCMAKE_INSTALL_MESSAGE=NEVER"
+	fi
+
+	args="${args} -DCMAKE_INSTALL_DEFAULT_COMPONENT_NAME=devel"
+
+	args="${args} -DCMAKE_INSTALL_PREFIX=${rdir_ins}"
+	args="${args} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+	# Since we're converting a colon separated list to semicolon separated list,
+	# we need to ensure the string is quoted. Otherwise the shell will treat
+	# the second item like another command.
+	if [ ! -z "${CMAKE_PREFIX_PATH}" ]; then
+		args="${args} -DCMAKE_PREFIX_PATH=\"${rdir_ins};$(echo "${CMAKE_PREFIX_PATH}" | sed "s/:/;/g")\""
+	else
+		args="${args} -DCMAKE_PREFIX_PATH=${rdir_ins}"
+	fi
+
+	ssh_call "Configure" "${RB_BHOST}" "${args}"
 }
 
-function deploy {
-    if [ -z "$DEPLOY_HOST" ]; then
-        echo >&2 "DEPLOY_HOST not set"
-        echo >&2 "Please set it using an IP address in .rbuild.conf, for example: DEPLOY_HOST=10.14.0.11"
-        exit 1
-    fi
-    echo Deploy $INSTALL_DIR/$BASENAME from $BUILD_HOST to $DEPLOY_HOST
-    $SSH -A $BUILD_HOST RSYNC_OLD_ARGS=1 rsync --del -avz -e "\"$SSH\"" --rsync-path="\"mkdir -p $INSTALL_DIR && rsync\"" "$INSTALL_DIR/$BASENAME/" "$DEPLOY_HOST:$INSTALL_DIR/$BASENAME"
+make_config()
+{
+	:
 }
 
-function deploy_source {
-    if [ -z "$DEPLOY_HOST" ]; then
-        echo >&2 "DEPLOY_HOST not set"
-        echo >&2 "Please set it using an IP address in .rbuild.conf, for example: DEPLOY_HOST=10.14.0.11"
-        exit 1
-    fi
-    echo Code push $STAGING_DIR from $BUILD_HOST to $DEPLOY_HOST
-    $SSH -A $BUILD_HOST RSYNC_OLD_ARGS=1 rsync --del -avz -e "\"$SSH\"" --rsync-path=\""mkdir -p $RBUILD_DIR && rsync\"" "$STAGING_DIR/" "$DEPLOY_HOST:$STAGING_DIR"
+auto_build()
+{
+	args=
+
+	args="-C${rdir_bin}"
+	args="${args} -j${RB_JOBS}"
+	if [ ${rb_verbosity} -ge 3 ]; then
+		args="${args} V=1"
+	fi
+	args="${args} GIT_REVISION=${GIT_REVISION}"
+	if [ ! -z "${rb_target}" ]; then
+		args="${args} ${rb_target}"
+	else
+		args="${args} install"
+	fi
+
+	ssh_call "Build" "${RB_BHOST}" "make ${args}"
 }
 
-function retract_source {
-    if [ -z "$DEPLOY_HOST" ]; then
-        echo >&2 "DEPLOY_HOST not set"
-        echo >&2 "Please set it using an IP address in .rbuild.conf, for example: DEPLOY_HOST=10.14.0.11"
-        exit 1
-    fi
-    echo Removing source code from $DEPLOY_HOST:$STAGING_DIR
-    $SSH -A $BUILD_HOST $SSH $DEPLOY_HOST rm -rf $STAGING_DIR
+cmake_build()
+{
+	args_b= # Build command and arguments
+	args_i= # Install command
+
+	if [ ! -z "${GIT_REVISION}" ]; then
+		args_b="${args_b} GIT_REVISION=${GIT_REVISION}"
+	fi
+
+	__cmake="cmake"
+	if [ ! -z "${CMAKE_EXE}" ]; then
+		__cmake=${CMAKE_EXE}
+	fi
+
+	args_b="${args_b} ${__cmake} --build ${rdir_bin}"
+	args_i="${args_i} ${__cmake} --install ${rdir_bin}"
+
+	if [ ! -z "${rb_target}" ]; then
+		args_b="${args_b} -t ${rb_target}"
+	fi
+
+	# Installation components. Pass installation components only if they're
+	# specified in the .rbuild.conf. And at the very least, always install 'dev'
+	# component.
+	# args_i="${args_i} --component \"devel\""
+
+	# On Ninja, if `-j` is left unspecified, it will run as many parallel jobs
+	# as there are CPUs on the build machine. Not ideal.
+	args_b="${args_b} -j ${RB_JOBS}"
+	if [ ${rb_verbosity} -ge 3 ]; then
+		args_b="${args_b} -v"
+		args_i="${args_i} -v"
+	fi
+
+	ssh_call "Build" "${RB_BHOST}" "${args_b} && ${args_i} --component devel && ${args_i} --component testing"
 }
 
-function dump_exclude_list {
-    cat <<_EOF_
-*.swp
-.git
-.hg
-Makefile.in
-aclocal.m4
-autom4te.cache
-compile
-config.guess
-config.h.in
-config.sub
-configure
-depcomp
-install-sh
-libtool.m4
-ltmain.sh
-ltoptions.m4
-ltsugar.m4
-ltversion.m4
-lt~obsolete.m4
-missing
-py-compile
-test-driver
-ylwrap
-build-aux
-_EOF_
+make_build()
+{
+	args=
+	env=""
+
+	if [ ! -z "${CC}" ]; then
+		env="${env} CC=${CC}"
+	fi
+	if [ ! -z "${CXX}" ]; then
+		env="${env} CXX=${CXX}"
+	fi
+	if [ ! -z "${AR}" ]; then
+		env="${env} AR=${AR}"
+	fi
+	if [ ! -z "${RANLIB}" ]; then
+		env="${env} RANLIB=${RANLIB}"
+	fi
+	if [ ! -z "${NM}" ]; then
+		env="${env} NM=${NM}"
+	fi
+	if [ ! -z "${LINKER}" ]; then
+		env="${env} LINKER=${LINKER}"
+	fi
+	if [ ! -z "${CCAS}" ]; then
+		env="${env} CCAS=${CCAS}"
+	fi
+	if [ ! -z "${CFLAGS}" ]; then
+		env="${env} CFLAGS=\"${CFLAGS}\""
+	fi
+
+	args="cd ${rdir_src};"
+	args="${args} ${env} gmake"
+	args="${args} -j${RB_JOBS}"
+	args="${args} DIR_BIN=${rdir_bin}"
+	args="${args} PREFIX=${rdir_ins}"
+	if [ ${rb_verbosity} -ge 2 ]; then
+		args="${args} V=1"
+	fi
+	if [ ! -z "${GMAKE_EXTRAS}" ]; then
+		args="${args} ${GMAKE_EXTRAS}"
+	fi
+	if [ ! -z "${rb_target}" ]; then
+		args="${args} -t ${rb_target}"
+	fi
+
+	ssh_call "Build" "${RB_BHOST}" "${args}"
 }
 
-noargs=1
-while getopts "he:scAaB:brutdD:SRoj:i:x" arg; do
-    unset noargs
-    case $arg in
-        h)
-            echo "Usage:"
-            echo -e "-s\t\tStage source code from the current directory to BUILD_HOST"
-            echo -e "-c\t\tRun 'make clean' on BUILD_HOST"
-            echo -e "-t\t\tRun 'make check' on BUILD_HOST"
-            echo -e "-A\t\tRun 'autoreconf --install' on BUILD_HOST"
-            echo -e "-a\t\tRun 'configure' on BUILD_HOST"
-            echo -e "-B TARGET\tRun 'make TARGET' on BUILD_HOST"
-            echo -e "-b\t\tRun 'make install' on BUILD_HOST"
-            echo -e "-r\t\tRemove build directory (when 'make clean' is not enough)"
-            echo -e "-u\t\tRemove install directory"
-            echo -e "-d\t\tDeploy binaries from BUILD_HOST to DEPLOY_HOST"
-            echo -e "-D HOST\t\tDeploy binaries from BUILD_HOST to HOST"
-            echo -e "-S\t\tDeploy source code from BUILD_HOST to DEPLOY_HOST (e.g. for GDB)"
-            echo -e "-R\t\tRemove source code from DEPLOY_HOST"
-            echo
-            echo -e "-e ENV\t\tSpecify a build environment. Made available as BUILD_ENV for the config file (default=debug)"
-            echo -e "-o\t\tShortcut to set BUILD_ENV=optimized"
-            echo -e "-j\t\tDefine number of build jobs to run simultaneously (default: 8)"
-            echo -e "-i FILE\t\tSpecify the rbuild configuration file (default = $HOME/.rbuild.conf)"
-            echo -e "-x\t\tDump built-in exclude list and exit"
-            exit 1
-            ;;
-        x)
-            dump_exclude_list
-            exit 0
-            ;;
-        e)
-            BUILD_ENV=${OPTARG}
-            ;;
-        s)
-            do_stage=1
-            ;;
-        c)
-            do_clean=1
-            ;;
-        t)
-            do_check=1
-            ;;
-        A)
-            do_autoreconf=1
-            ;;
-        a)
-            do_configure=1
-            ;;
-        B)
-            build_target=${OPTARG}
-            ;;
-        r)
-            do_rm_build_dir=1
-            ;;
-        u)
-            do_rm_install_dir=1
-            ;;
-        b)
-            do_build=1
-            ;;
-        d)
-            do_deploy=1
-            ;;
-        D)
-            deploy_host=${OPTARG}
-            do_deploy=1
-            ;;
-        S)
-            do_deploy_source=1
-            ;;
-        R)
-            do_retract_source=1
-            ;;
-        o)
-            BUILD_ENV=optimized
-            ;;
-        j)
-            BUILD_JOBS="${OPTARG}"
-            ;;
-        i)
-            config_file=${OPTARG}
-            ;;
-    esac
+auto_test()
+{
+	args=
+
+	args="-C${rdir_bin}"
+	args="${args} -j${RB_JOBS}"
+	if [ ${rb_verbosity} -ge 4 ]; then
+		args="${args} V=1"
+	fi
+	args="${args} GIT_REVISION=${GIT_REVISION}"
+	if [ ! -z "${rb_target}" ]; then
+		args="${args} ${rb_target}"
+	else
+		args="${args} check"
+	fi
+
+	ssh_call "Test" "${RB_BHOST}" "make ${args}"
+}
+
+cmake_test()
+{
+	args=
+
+	if [ ! -z "${GIT_REVISION}" ]; then
+		args="GIT_REVISION=${GIT_REVISION}"
+	fi
+
+	if [ -z "${CTEST_EXE}" ]; then
+		args="${args} ctest"
+	else
+		args="${args} ${CTEST_EXE}"
+	fi
+
+	args="${args} --output-on-failure"
+	args="${args} --stop-on-failure"
+	args="${args} -j ${RB_JOBS}"
+	args="${args} -O ${rdir_bin}/tests.log"
+
+	if [ ${rb_verbosity} -ge 4 ]; then
+		args="${args} -VV --debug"
+	elif [ ${rb_verbosity} -ge 3 ]; then
+		args="${args} -VV"
+	elif [ ${rb_verbosity} -ge 2 ]; then
+		args="${args} -V"
+	fi
+
+	ssh_call "Test" "${RB_BHOST}" "cd ${rdir_bin}; ${args}"
+}
+
+make_test()
+{
+	:
+}
+
+auto_package()
+{
+	args=
+
+	if [ ${rb_verbosity} -ge 4 ]; then
+		args="${args} -v"
+	fi
+	args="${args} -caf"
+	args="${args} ${RB_ROOT}/${rb_build_mode}.tar.xz"
+	args="${args} *"
+
+	ssh_call "Package" "${RB_BHOST}" "cd ${rdir_ins} && tar ${args}"
+}
+
+cmake_package()
+{
+	args=
+
+	if [ ${rb_verbosity} -ge 1 ]; then
+		args="${args} -V"
+	fi
+	if [ ${rb_verbosity} -ge 2 ]; then
+		args="${args} --trace"
+	fi
+	if [ ${rb_verbosity} -ge 3 ]; then
+		args="${args} --trace-expand"
+	fi
+	if [ ${rb_verbosity} -ge 4 ]; then
+		args="${args} --debug"
+	fi
+
+	# args="${args} -DCPACK_THREADS=${RB_JOBS}"
+
+	ssh_call "Package" "${RB_BHOST}" "cd ${rdir_bin} && ${CPACK_EXE} -G RPM ${args}"
+}
+
+make_package()
+{
+	:
+}
+
+rb_deploy()
+{
+	cmd=
+	r_args= # For rSync
+	s_args= # For SSH
+
+	r_args="-avz"
+	if [ $rb_verbosity -ge 2 ]; then
+		r_args="${r_args} -v --progress"
+	else
+		r_args="${r_args} -q"
+	fi
+	r_args="${r_args} --del"
+
+	s_args="ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ForwardAgent=yes"
+
+	cmd="rsync ${r_args} -e \"${s_args}\""
+	cmd="${cmd} --rsync-path=\"mkdir -p ${rdir_ins} && ${RSYNC}\""
+	cmd="${cmd} ${rdir_ins}"
+	cmd="${cmd} ${RUSER}@${RB_DHOST}:${rdir_ins}/"
+
+	ssh_call "Deploy" "${RB_BHOST}" "${cmd}"
+}
+
+rb_set_cfg_file()
+{
+	ldir=
+
+	rb_cfg_file=
+	ldir=$(upsearch "${1}")
+	if [ ! -z "${ldir}" ]; then
+		rb_cfg_file="${ldir}/${1}"
+	elif [ -e "${HOME}/${1}" ]; then
+		rb_cfg_file="${HOME}/${1}"
+	fi
+}
+
+rb_set_build_type()
+{
+	if [ ${1} = "debug" ]; then
+		rb_build_mode=debug
+		CMAKE_BUILD_TYPE=Debug
+	elif [ ${1} = "optimized" ] || [ ${1} = "optimised" ]; then
+		rb_build_mode=optimized
+		CMAKE_BUILD_TYPE=RelWithDebInfo
+	else
+		echo "Build type must be one of ['debug', 'optimized']. Got '-e${1}'"
+		exit 1
+	fi
+}
+
+is_integer()
+{
+	case "${1#[+-]}" in
+		(*[![:digit:]]*)  return 1 ;;
+		(*)               return 0 ;;
+	esac
+}
+
+rb_set_build_jobs()
+{
+	jobs="${1}"
+	is_integer "${jobs}"
+	if [ $? -ne 0 ]; then
+		echo "Jobs must be an integer. Got '-j${jobs}'"
+		exit 1
+	fi
+	if [ "${jobs}" -le 0 ] || [ "${jobs}" -gt 255 ]; then
+		echo "Invalid job count. Must be between 0 and 255"
+		exit 1
+	fi
+	if [ ${jobs} -gt 0 ]; then
+		RB_JOBS=${jobs}
+	fi
+}
+
+rb_set_reset_level()
+{
+	level=${1}
+
+	is_integer "${level}"
+	if [ $? -ne 0 ]; then
+		echo "Reset level must be an integer between 1-4. Got '-r${level}'"
+		exit 1
+	fi
+	if [ "${level}" -lt 1 ] || [ "${level}" -gt 4 ]; then
+		echo "Reset level must be between 1-4. Got '-r${level}'"
+		exit 1
+	fi
+	__rb_reset_level=${level}
+}
+
+rb_cfg_set_git()
+{
+	is_git=$(upsearch ".git")
+	if [ ! -z "${is_git}" ]; then
+		GIT_REVISION=$(git rev-parse HEAD)
+		export GIT_REVISION
+	fi
+}
+
+RB_JOBS=${__rb_def_jobs}
+rb_set_cfg_file "${__rb_def_cfg_name}"
+rb_cfg_set_git
+
+while getopts "bB:cC:dE:e:hj:npr:stv" opt; do
+	case "${opt}" in
+		b) __rb_is_build=1; __rb_is_rsync=1         ;;
+		B) rb_target=${OPTARG}                      ;;
+		c) __rb_is_config=1; __rb_is_rsync=1        ;;
+		C) rb_set_cfg_file "${OPTARG}"              ;;
+		d) __rb_is_deploy=1                         ;;
+		e) rb_set_build_type "${OPTARG}"            ;;
+		h) rb_help 0                                ;;
+		j) rb_set_build_jobs "${OPTARG}"            ;;
+		n) __rb_is_dryrun=1                         ;;
+		p) __rb_is_pack=1                           ;;
+		r) rb_set_reset_level "${OPTARG}"           ;;
+		s) __rb_is_rsync=1                          ;;
+		t) __rb_is_test=1; __rb_is_rsync=1          ;;
+		v) rb_verbosity=$(expr ${rb_verbosity} + 1) ;;
+		*) rb_help 1 "${OPTARG}"                    ;;
+	esac
 done
-shift $(expr $OPTIND - 1 )
-
-if [ $noargs ]; then
-    do_stage=1
-    do_build=1
+if [ $OPTIND -eq 1 ]; then
+	# Default behaviour if no options are given.
+	__rb_is_rsync=1
+	__rb_is_build=1
+	exit 0
 fi
 
-export BUILD_ENV
-
-load_conf $config_file
-
-
-if [ -n "$deploy_host" ]; then
-    DEPLOY_HOST=$deploy_host
+# If verbosity is too high, start true crime drama!
+if [ ${rb_verbosity} -ge 4 ]; then
+	__ssh_flags="${__ssh_flags} -o LogLevel=VERBOSE"
+else
+	__ssh_flags="${__ssh_flags} -o LogLevel=QUIET"
 fi
 
-AUTORECONF_VARS="${AUTORECONF_VARS:-ACLOCAL_PATH=\'$ACLOCAL_PATH\'}"
-AUTORECONF_VARS+=" $EXTRA_AUTORECONF_VARS"
+rb_init
 
-CONFIGURE_VARS="${CONFIGURE_VARS:-PKG_CONFIG_PATH=\'$PKG_CONFIG_PATH\' ACLOCAL_PATH=\'$ACLOCAL_PATH\' CC=\'$CC\' CFLAGS=\'$CFLAGS\' LDFLAGS=\'$LDFLAGS\' CXX=\'$CXX\' CXXFLAGS=\'$CXXFLAGS\' CCAS=gcc CCASFLAGS=}"
-CONFIGURE_VARS+=" $EXTRA_CONFIGURE_VARS"
-
-CONFIGURE_ARGS="${CONFIGURE_ARGS:---prefix $INSTALL_DIR/$BASENAME}"
-CONFIGURE_ARGS+=" $EXTRA_CONFIGURE_ARGS"
-
-if [ $do_stage ]; then
-    stage || exit 1
+if [ $__rb_reset_level -ne 0 ]; then
+	rb_reset
 fi
-
-if [ $do_clean ]; then
-    clean || exit 1
+if [ $__rb_is_rsync -eq 1 ]; then
+	rb_sync
 fi
-
-if [ $do_rm_build_dir ]; then
-    rm_build_dir || exit 1
+if [ $__rb_is_config -eq 1 ]; then
+	${rb_method}_config
 fi
-
-if [ $do_rm_install_dir ]; then
-    rm_install_dir || exit 1
+if [ $__rb_is_build -eq 1 ]; then
+	${rb_method}_build
 fi
-
-if [ $do_autoreconf ]; then
-    autoreconf || exit 1
+if [ $__rb_is_test -eq 1 ]; then
+	${rb_method}_test
 fi
-
-if [ $do_configure ]; then
-    configure || exit 1
+if [ $__rb_is_pack -eq 1 ]; then
+	${rb_method}_package
 fi
-
-if [ $do_build ]; then
-    build "install" || exit 1
+if [ $__rb_is_deploy -eq 1 ]; then
+	rb_deploy
 fi
-
-if [ $build_target ]; then
-    build $build_target || exit 1
-fi
-
-if [ $do_check ]; then
-    check || exit 1
-fi
-
-if [ $do_deploy ]; then
-    deploy || exit 1
-fi
-
-if [ $do_deploy_source ]; then
-    deploy_source || exit 1
-fi
-
-if [ $do_retract_source ]; then
-    retract_source || exit 1
-fi
-
-# vim: sw=4 sts=4 expandtab

--- a/rbuild
+++ b/rbuild
@@ -291,7 +291,7 @@ rb_sync()
 	rb_prep_exclist
 
 	r_args="-chlrz"
-	if [ $rb_verbosity -ge 2 ]; then
+	if [ $rb_verbosity -ge 4 ]; then
 		r_args="${r_args} -v --progress"
 	else
 		r_args="${r_args} -q"
@@ -357,11 +357,9 @@ rb_init()
 		rb_method="cmake"
 	elif [ -f "${ldir_src}/configure.ac" ]; then
 		rb_method="auto"
-	elif [ -f "${ldir_src}/Makefile" ] || [ -f "${ldir_src}/GNUMakefile" ]; then
-		rb_method="make"
 	else
 		echo "Could not recognise build method."
-		echo "No Makefile/CMakeLists.txt/configure.ac found in ${ldir_src}"
+		echo "No CMakeLists.txt/configure.ac found in ${ldir_src}"
 		exit 1
 	fi
 
@@ -413,15 +411,16 @@ rb_init()
 
 		RB_JOBS=${__saved_jobs}
 	fi
+
+	if [ ! -z "${INSTALL_DIR}" ]; then
+		rdir_ins=${INSTALL_DIR}
+	fi
 }
 
 # Reset remote site
 rb_reset()
 {
 	rm_cmd="rm -rf"
-	if [ ${rb_verbosity} -ge 2 ]; then
-		rm_cmd="${rm_cmd} -v"
-	fi
 
 	if [ ${__rb_reset_level} -eq 1 ]; then
 		if [ "${rb_method}" = "cmake" ]; then
@@ -445,13 +444,11 @@ rb_reset()
 			fi
 
 			ssh_call "Reset-1" "${RB_BHOST}" "${args}"
-		elif [ "${rb_method}" = "auto" ] || [ "${rb_method}" = "make" ]; then
+		elif [ "${rb_method}" = "auto" ] then
 			args="make"
 			args="${args} -C${rdir_bin}"
 			args="${args} -j${RB_JOBS}"
 
-			# We assume both handmade Makefile and autotools generated Makefile
-			# use `V=1` to enable verbosity.
 			if [ ${rb_verbosity} -ge 2 ]; then
 				args="${args} V=1"
 			fi
@@ -550,7 +547,7 @@ auto_config()
 	cmd=
 	cmd="${envs} ${rdir_src}/configure"
 	cmd="${cmd} --prefix=${rdir_ins}"
-	if [ -z "${AUTO_EXTRA_CONFIGURE_ARGS}" ]; then
+	if [ ! -z "${AUTO_EXTRA_CONFIGURE_ARGS}" ]; then
 		cmd="${cmd} ${AUTO_EXTRA_CONFIGURE_ARGS}"
 	fi
 	ssh_call "Configure" \
@@ -576,9 +573,9 @@ cmake_config()
 	else
 		args="${args} ${CMAKE_EXE}"
 	fi
-	args="${args} -S${rdir_src}"
+	args="${args} -H${rdir_src}"
 	args="${args} -B${rdir_bin}"
-	args="${args} -Werror=dev"
+	# args="${args} -Werror=dev"
 	args="${args} --warn-uninitialized"
 	args="${args} --no-warn-unused-cli"
 
@@ -615,12 +612,12 @@ cmake_config()
 	# through rbuild CLI. For large projects, this will print way too many
 	# lines obstructing the real stuff. Should this be configured here under
 	# `-v` settings?
-	if [ ${rb_verbosity} -ge 2 ]; then
-		args="${args} -DCMAKE_INSTALL_MESSAGE=ALWAYS"
-	else
-		args="${args} -DCMAKE_INSTALL_MESSAGE=NEVER"
-	fi
-
+	# if [ ${rb_verbosity} -ge 2 ]; then
+	# 	args="${args} -DCMAKE_INSTALL_MESSAGE=ALWAYS"
+	# else
+	# 	args="${args} -DCMAKE_INSTALL_MESSAGE=NEVER"
+	# fi
+	args="${args} -DCMAKE_INSTALL_MESSAGE=ALWAYS"
 	args="${args} -DCMAKE_INSTALL_DEFAULT_COMPONENT_NAME=devel"
 
 	args="${args} -DCMAKE_INSTALL_PREFIX=${rdir_ins}"
@@ -637,18 +634,13 @@ cmake_config()
 	ssh_call "Configure" "${RB_BHOST}" "${args}"
 }
 
-make_config()
-{
-	:
-}
-
 auto_build()
 {
 	args=
 
 	args="-C${rdir_bin}"
 	args="${args} -j${RB_JOBS}"
-	if [ ${rb_verbosity} -ge 3 ]; then
+	if [ ${rb_verbosity} -ge 2 ]; then
 		args="${args} V=1"
 	fi
 	args="${args} GIT_REVISION=${GIT_REVISION}"
@@ -689,61 +681,20 @@ cmake_build()
 
 	# On Ninja, if `-j` is left unspecified, it will run as many parallel jobs
 	# as there are CPUs on the build machine. Not ideal.
-	args_b="${args_b} -j ${RB_JOBS}"
-	if [ ${rb_verbosity} -ge 3 ]; then
-		args_b="${args_b} -v"
-		args_i="${args_i} -v"
+	# args_b="${args_b} -j ${RB_JOBS}"
+	if [ "${CMAKE_GENERATOR}" == "Ninja" ]; then
+		args_b="${args_b} -- -k128"
 	fi
-
-	ssh_call "Build" "${RB_BHOST}" "${args_b} && ${args_i} --component devel && ${args_i} --component testing"
-}
-
-make_build()
-{
-	args=
-	env=""
-
-	if [ ! -z "${CC}" ]; then
-		env="${env} CC=${CC}"
-	fi
-	if [ ! -z "${CXX}" ]; then
-		env="${env} CXX=${CXX}"
-	fi
-	if [ ! -z "${AR}" ]; then
-		env="${env} AR=${AR}"
-	fi
-	if [ ! -z "${RANLIB}" ]; then
-		env="${env} RANLIB=${RANLIB}"
-	fi
-	if [ ! -z "${NM}" ]; then
-		env="${env} NM=${NM}"
-	fi
-	if [ ! -z "${LINKER}" ]; then
-		env="${env} LINKER=${LINKER}"
-	fi
-	if [ ! -z "${CCAS}" ]; then
-		env="${env} CCAS=${CCAS}"
-	fi
-	if [ ! -z "${CFLAGS}" ]; then
-		env="${env} CFLAGS=\"${CFLAGS}\""
-	fi
-
-	args="cd ${rdir_src};"
-	args="${args} ${env} gmake"
-	args="${args} -j${RB_JOBS}"
-	args="${args} DIR_BIN=${rdir_bin}"
-	args="${args} PREFIX=${rdir_ins}"
 	if [ ${rb_verbosity} -ge 2 ]; then
-		args="${args} V=1"
-	fi
-	if [ ! -z "${GMAKE_EXTRAS}" ]; then
-		args="${args} ${GMAKE_EXTRAS}"
-	fi
-	if [ ! -z "${rb_target}" ]; then
-		args="${args} -t ${rb_target}"
+		if [ "${CMAKE_GENERATOR}" == "Ninja" ]; then
+			args_b="${args_b} -v"
+			args_i="${args_i} -v"
+		else
+			args_b="${args_b} -- VERBOSE=1"
+		fi
 	fi
 
-	ssh_call "Build" "${RB_BHOST}" "${args}"
+	ssh_call "Build" "${RB_BHOST}" "${args_b} && ${args_i}"
 }
 
 auto_test()
@@ -751,8 +702,8 @@ auto_test()
 	args=
 
 	args="-C${rdir_bin}"
-	args="${args} -j${RB_JOBS}"
-	if [ ${rb_verbosity} -ge 4 ]; then
+	# args="${args} -j${RB_JOBS}"
+	if [ ${rb_verbosity} -ge 3 ]; then
 		args="${args} V=1"
 	fi
 	args="${args} GIT_REVISION=${GIT_REVISION}"
@@ -795,16 +746,11 @@ cmake_test()
 	ssh_call "Test" "${RB_BHOST}" "cd ${rdir_bin}; ${args}"
 }
 
-make_test()
-{
-	:
-}
-
 auto_package()
 {
 	args=
 
-	if [ ${rb_verbosity} -ge 4 ]; then
+	if [ ${rb_verbosity} -ge 3 ]; then
 		args="${args} -v"
 	fi
 	args="${args} -caf"
@@ -833,12 +779,7 @@ cmake_package()
 
 	# args="${args} -DCPACK_THREADS=${RB_JOBS}"
 
-	ssh_call "Package" "${RB_BHOST}" "cd ${rdir_bin} && ${CPACK_EXE} -G RPM ${args}"
-}
-
-make_package()
-{
-	:
+	ssh_call "Package" "${RB_BHOST}" "cd ${rdir_bin} && ${CPACK_EXE} -G TGZ ${args}"
 }
 
 rb_deploy()
@@ -848,7 +789,7 @@ rb_deploy()
 	s_args= # For SSH
 
 	r_args="-avz"
-	if [ $rb_verbosity -ge 2 ]; then
+	if [ $rb_verbosity -ge 3 ]; then
 		r_args="${r_args} -v --progress"
 	else
 		r_args="${r_args} -q"

--- a/sample.rbuild.conf
+++ b/sample.rbuild.conf
@@ -1,53 +1,146 @@
-# This file should be copied to ~/.rbuild.conf on the local machine
+#! /bin/sh
 
-# CONFIGURE_ARGS default to --prefix $INSTALL_DIR/$BASENAME
-# INSTALL_DIR defaults to '$HOME/.local'. Single quotes can be
-# used to refer to $HOME on the BUILD_HOST and DEPLOY_HOST instead
-# of the local machine.
-# BASENAME defaults to the basename of LOCAL_DIR
-# LOCAL_DIR is detected by searching from the current directory towards the root directory
-# for a directory containing any of LOCAL_DIR_ANCHORS
-# LOCAL_DIR_ANCHORS defaults to ".hg .git configure.ac"
-# SSH defaults to "ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ForwardAgent=yes"
+# This file is expected to be placed named `.rbuild.conf` and place in `$
+# {HOME}/` or in some parent directory of all the local projects.
 
+# This following variables are of importance:
+#
+# rbuild exposed variables:
+# ------------------------------------------------------------------------------
+# rb_build_mode=
+#     Contains one of `debug` or `optimized` based on how rbuild was invoked
+#     from command line. Defaults to `debug`.
+#
+# rb_method=
+#     Contains one of `auto` (for auto-tools) or `cmake` (for CMake) referring
+#     to the build method. Note, if both auto-tools and CMake build scripts
+#     were found in root of project repository, CMake is given preference.
+#
+# IMPORTANT Note:
+# ==============================================================================
+# Due to the nature of auto-tools, the configuration script will be loaded
+# twice. The first time load is to get '$RB_ROOT' to generate remote build and
+# source paths. And second time, to allow for configuration script to adjust
+# other variables based on the newly discovered paths. As such 3 new variables
+# are made available in second round:
+#
+# rdir_src=
+#     The remote source directory.
+#
+# rdir_bin=
+#     The remote binary directory where all binaries are built.
+#
+# rdir_ins=
+#     The remote installation path prefix where installable binaries are stored.
+#
+# Generic configuration variables:
+# ------------------------------------------------------------------------------
+# RUSER=
+#    Optional. The user-name on the remote build server. If left unspecified,
+#    rbuild will default to local $USER or whatever is specified for the
+#    $RB_BHOST in ~/.ssh/config
+#
+# RB_BHOST=
+#     The remote build host where all development tools are available.
+#
+# RB_DHOST=
+#     The remote site where the build binaries will be deployed. Note that,
+#     there should be free SSH access from $RB_BHOST to $RB_DHOST for $RUSER as
+#     the installable artefacts are copied directly between them.
+#
+# RB_ROOT=
+#     The root directory on the remote build host where sources are stored and
+#     binaries are generated.
+#
+# RB_JOBS=
+#     Number of parallel jobs to use. If left unspecified, it defaults to
+#     whatever CPUs the dev computer has where rbuild is called from.
+#
+# RSYNC=
+#     Optional. The path to `rsync` application. On some build servers
+#     (e.g. Solaris 5.10), this may not be available on default $PATH in which
+#     case RSYNC must be set to `RSYNC=/usr/sfw/bin/rsync`.
+#
+# CMake specific variables:
+# ------------------------------------------------------------------------------
+# CMAKE_EXE=
+#     Optional. Path to CMake executable. On some older Linux distros CMake 2.x
+#     and 3.x were available as `/usr/bin/cmake` and `/usr/bin/cmake3`. If this
+#     variable is left unspecified, it defaults to `cmake` available on default
+#     $PATH. When specified, it must point to the correct location of CMake
+#     executable.
+#
+# CTEST_EXE=
+#     Same as `CMAKE_EXE=`, but for `ctest` executable.
+#
+# Build assistance variables (generic):
+# ------------------------------------------------------------------------------
+# PKG_CONFIG_PATH=
+#     Extra paths for pkg-config on remote build server.
+#
+# Build assistance variables (CMake):
+# ------------------------------------------------------------------------------
+# CMAKE_EXTRAS=
+#     Optional. Any extra options to be passed to a call to CMake for
+#     configuration of the project.
+#
+# CMAKE_GENERATOR=
+#     Optional. The CMake generator. If left unspecified, it defaults to 'Unix
+#     Makefiles' or whatever is suitable for the remote build server. If
+#     specified it must contain a valid value as accepted by CMake's `-G`
+#     argument.
+#
+# CMAKE_PREFIX_PATH=
+#     A colon (not semicolon) separated list of paths that CMake will look for
+#     dependencies. The rbuild tool will convert separators to semicolon later.
+#     This restriction is to play around shell limitations.
+#
+# Build assistance variables (auto-tools):
+# ------------------------------------------------------------------------------
+# AUTO_EXTRA_CONFIGURE_ARGS=
+#     Any extra arguments passed to `./configure` script.
+#
+# Other influential variables:
+# ------------------------------------------------------------------------------
+# If the configuration specifies any of these variables, they can influence how
+# `./configure` or `cmake ...` are invoked.
+#
+# AR=
+# CC=
+# CCAS=
+# CXX=
+# LINKER=
+# NM=
+# RANLIB=
+# STRIP=
 
-# BUILD_ENV contains the argument to the -e option of rbuild
-# and defaults to "debug"
-case $BUILD_ENV in
-debug)
-    # We can override the CFLAGS variable.
-    # It will be passed to the remote build.
-    CFLAGS="-fsanitize=address -ggdb3 -O0"
+RUSER=ape
+RSYNC=/usr/sfw/bin/rsync
 
-    # Any EXTRA_CONFIGURE_ARGS are appended to CONFIGURE_ARGS
-    EXTRA_CONFIGURE_ARGS="--enable-valgrind-testing"
+RB_BHOST=solaris.dev.home.lan
+RB_DHOST=solaris.vm.home.lan
+RB_ROOT=/exports/home/${RUSER}/.rb-main
+
+CMAKE_EXE=/opt/csw/bin/cmake
+CTEST_EXE=/opt/csw/bin/ctest
+# CMAKE_GENERATOR=Ninja
+CMAKE_EXTRAS=""
+CMAKE_EXTRAS="${CMAKE_EXTRAS} -DBUILD_DOCS=Off"
+CMAKE_EXTRAS="${CMAKE_EXTRAS} -DBUILD_TESTS=On"
+
+case "${rb_type}" in
+    debug)
+        CMAKE_EXTRAS="${CMAKE_EXTRAS} -DENABLE_ASAN=On"
+
+        CFLAGS="-fsanitize=address -ggdb3 -O0"
+        AUTO_EXTRA_CONFIGURE_ARGS="--enable-valgrind-testing"
     ;;
-optimized)
-    CFLAGS="-ggdb3 -O3"
-    EXTRA_CONFIGURE_ARGS="--enable-optimizations"
+    optimized)
+        CMAKE_EXTRAS="${CMAKE_EXTRAS} -DENABLE_ASAN=Off"
+
+        CFLAGS="-ggdb3 -O3"
+        AUTO_EXTRA_CONFIGURE_ARGS="--enable-optimizations"
     ;;
-asan)
-    CFLAGS="-fsanitize=address -ggdb3 -O0"
-    ;;
-*)
+    *)
     ;;
 esac
-
-# We can override the compiler used
-CC=/opt/rh/devtoolset-4/root/usr/bin/gcc
-
-# PKG_CONFIG_PATH is passed to the remote build.
-# Use double-quotes to interpret $HOME on the remote machine
-PKG_CONFIG_PATH='$HOME/.local/libnio/lib/pkgconfig'
-
-# BUILD_HOST is mandatory
-BUILD_HOST=builder
-
-# DEPLOY_HOST is required for -d
-DEPLOY_HOST=staging
-
-# Runs make -j $BUILD_JOBS
-# BUILD_JOBS=10
-
-# Empty BUILD_JOBS will run make -j
-# BUILD_JOBS=


### PR DESCRIPTION
This patch makes a few important changes.

The script is now POSIXly correct and works on most shells. It has been verified and known to work on various operating systems such as MacOS, Solaris, Linux and NetBSD.

The rbuild now supports Auto-tools, CMake and GNUMake.

Simplifies and redefines command-line so the same CLI options produce similar effect for all supported build systems. As a result, `-Aa` is now simply `-c`. In case of auto-tools, it will automatically decide whether to run `autoreconf --install` on this CLI option.

Updates sample rbuild.conf